### PR TITLE
fix: remove libamdhip fix since new version of review-tools on the store

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -162,24 +162,3 @@ parts:
       chmod +x $CRAFT_PRIME/usr/bin/yq
       rm -rf $CRAFT_PRIME/local-ros
 
-  fix-execstack:
-    plugin: nil
-    after:
-      - husarion-depthai
-      - local-files
-      - husarion-snap-common
-    build-packages:
-      - execstack
-    override-prime: |
-      set -eu
-      craftctl default
-
-      choosen_files=(
-        usr/lib/x86_64-linux-gnu/libamdhip64.so*
-      )
-
-      for f in "${choosen_files[@]}"; do
-        if [ -f "$f" ]; then
-          execstack -c "$f"
-        fi
-      done


### PR DESCRIPTION
Since [this MR](https://code.launchpad.net/~gbeuzeboc/review-tools/+git/review-tools/+merge/469447) got merged and is now available on [`latest/stable` in the store](https://snapcraft.io/review-tools) the fix is not necessary anymore.

Feel free to merge if you don't want the fix to appear in your snap