### PR TITLE
Document post_install.sh + refresh it on snap refresh

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,19 +64,19 @@ ______________________________________________________________________
 
 ## 2. Tech stack
 
-| Layer                | Technology                                                                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Packaging            | snapcraft (\`extensions: ros2-{humble                                                                                                      |
-| Manifest templating  | Jinja2 (`render_template.py` + `ROS_DISTRO` env var)                                                                                       |
-| Application language | Python (ROS 2 launch), Bash (hooks + wrappers), C++ via `depthai-ros` (apt)                                                                |
-| ROS 2                | `humble` or `jazzy` (matrix)                                                                                                               |
-| Camera SDK           | `depthai-core` + `depthai_ros_driver` (apt: `ros-{distro}-depthai-ros`)                                                                    |
-| Image transport      | `image_transport`, `image_transport_plugins`, `ffmpeg_image_transport` (libx264)                                                           |
-| RMW                  | FastDDS (default from extension) + Cyclone DDS (`rmw-cyclonedds-cpp`) + Zenoh (`rmw-zenoh-cpp`); selected at runtime                        |
-| DDS XML              | FastDDS profiles (UDP, SHM) + CycloneDDS XML (UDP localhost) + Zenoh json5. Files in `husarion-snap-common@0.13.0`.                        |
-| CI                   | GitHub Actions (`snapcore/action-build`, `snapcore/action-publish`) + `pre-commit` (mdformat) in `ci.yaml`                                 |
-| Build orchestration  | `just` (justfile)                                                                                                                          |
-| External shared      | [`husarion/husarion-snap-common@0.13.0`](https://github.com/husarion/husarion-snap-common) — common ROS configuration / hooks / validators |
+| Layer | Technology |
+| -- | -- |
+| Packaging | snapcraft (\`extensions: ros2-{humble |
+| Manifest templating | Jinja2 (`render_template.py` + `ROS_DISTRO` env var) |
+| Application language | Python (ROS 2 launch), Bash (hooks + wrappers), C++ via `depthai-ros` (apt) |
+| ROS 2 | `humble` or `jazzy` (matrix) |
+| Camera SDK | `depthai-core` + `depthai_ros_driver` (apt: `ros-{distro}-depthai-ros`) |
+| Image transport | `image_transport`, `image_transport_plugins`, `ffmpeg_image_transport` (libx264) |
+| RMW | FastDDS (default from extension) + Cyclone DDS (`rmw-cyclonedds-cpp`) + Zenoh (`rmw-zenoh-cpp`); selected at runtime |
+| DDS XML | FastDDS profiles (UDP, SHM) + CycloneDDS XML (UDP localhost) + Zenoh json5. Files in `husarion-snap-common@0.13.0`. |
+| CI | GitHub Actions (`snapcore/action-build`, `snapcore/action-publish`) + `pre-commit` (mdformat) in `ci.yaml` |
+| Build orchestration | `just` (justfile) |
+| External shared | [`husarion/husarion-snap-common@0.13.0`](https://github.com/husarion/husarion-snap-common) — common ROS configuration / hooks / validators |
 
 ______________________________________________________________________
 
@@ -130,17 +130,17 @@ husarion-depthai-snap/
 
 ### Where things go in the final snap
 
-| Source                                                         | Destination in the snap                                                                                                             | Mechanism                                                                                                                                               |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `snap/local/*.sh`                                              | `$SNAP/usr/bin/`                                                                                                                    | part `local-files` (plugin: dump)                                                                                                                       |
-| `snap/local/*.py`                                              | `$SNAP/usr/bin/`                                                                                                                    | same as above                                                                                                                                           |
-| `snap/local/*.yaml`                                            | `$SNAP/usr/share/husarion-depthai/config/` (read-only template) → `$SNAP_DATA/` (writable runtime via install + post-refresh hooks) | same as above + hooks                                                                                                                                   |
-| `husarion-snap-common@0.13.0/local-ros/*.sh`                   | `$SNAP/usr/bin/`                                                                                                                    | part `husarion-snap-common` (plugin: dump from git)                                                                                                     |
-| `husarion-snap-common@0.13.0/local-ros/*.xml`                  | `$SNAP/usr/share/husarion-snap-common/config/`                                                                                      | same as above                                                                                                                                           |
-| `husarion-snap-common@0.13.0/local-ros/ros.env`                | `$SNAP/usr/share/husarion-snap-common/config/`                                                                                      | same as above                                                                                                                                           |
-| `yq` from GitHub releases (v4.35.1)                            | `$SNAP/usr/bin/yq`                                                                                                                  | override-build + override-prime                                                                                                                         |
-| apt: `ros-{distro}-depthai-ros` (+ image_transport, ffmpeg, …) | `$SNAP/opt/ros/{distro}/...`                                                                                                        | stage-packages in part `husarion-depthai`                                                                                                               |
-| `ros/husarion_depthai_pipeline/`                               | `$SNAP/opt/ros/{distro}/lib/libhusarion_depthai_pipeline.so` (+ plugins.xml, ament index)                                           | part `husarion-depthai-pipeline` (plugin: colcon) — built against the staged driver; pluginlib autoloads it when a preset sets `camera.i_pipeline_type` |
+| Source | Destination in the snap | Mechanism |
+| -- | -- | -- |
+| `snap/local/*.sh` | `$SNAP/usr/bin/` | part `local-files` (plugin: dump) |
+| `snap/local/*.py` | `$SNAP/usr/bin/` | same as above |
+| `snap/local/*.yaml` | `$SNAP/usr/share/husarion-depthai/config/` (read-only template) → `$SNAP_DATA/` (writable runtime via install + post-refresh hooks) | same as above + hooks |
+| `husarion-snap-common@0.13.0/local-ros/*.sh` | `$SNAP/usr/bin/` | part `husarion-snap-common` (plugin: dump from git) |
+| `husarion-snap-common@0.13.0/local-ros/*.xml` | `$SNAP/usr/share/husarion-snap-common/config/` | same as above |
+| `husarion-snap-common@0.13.0/local-ros/ros.env` | `$SNAP/usr/share/husarion-snap-common/config/` | same as above |
+| `yq` from GitHub releases (v4.35.1) | `$SNAP/usr/bin/yq` | override-build + override-prime |
+| apt: `ros-{distro}-depthai-ros` (+ image_transport, ffmpeg, …) | `$SNAP/opt/ros/{distro}/...` | stage-packages in part `husarion-depthai` |
+| `ros/husarion_depthai_pipeline/` | `$SNAP/opt/ros/{distro}/lib/libhusarion_depthai_pipeline.so` (+ plugins.xml, ament index) | part `husarion-depthai-pipeline` (plugin: colcon) — built against the staged driver; pluginlib autoloads it when a preset sets `camera.i_pipeline_type` |
 
 ______________________________________________________________________
 
@@ -300,14 +300,14 @@ ______________________________________________________________________
 
 ## 6. External integrations
 
-| Integration            | Method                                                                    | Pinned version                                                             |
-| ---------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `husarion-snap-common` | git clone in `parts.husarion-snap-common.source`                          | branch/tag `0.13.0`                                                        |
-| `depthai-ros`          | apt (`ros-{distro}-depthai-ros`) from the ROS 2 distro repo               | dynamic (`apt-cache policy …\| Candidate`)                                 |
-| `yq`                   | curl from GitHub releases                                                 | `v4.35.1`                                                                  |
-| ROS 2 base             | snapcraft extension `ros2-{distro}-ros-base`                              | distro = humble \| jazzy                                                   |
-| Snap Store             | `snapcore/action-publish@v1`                                              | tracks: `humble/edge`, `humble/candidate`, `jazzy/edge`, `jazzy/candidate` |
-| OAK-x camera           | USB (raw-usb plug) or PoE/IP (preset `oak-d-pro-poe`, `i_ip: 10.15.20.6`) | —                                                                          |
+| Integration | Method | Pinned version |
+| -- | -- | -- |
+| `husarion-snap-common` | git clone in `parts.husarion-snap-common.source` | branch/tag `0.13.0` |
+| `depthai-ros` | apt (`ros-{distro}-depthai-ros`) from the ROS 2 distro repo | dynamic (`apt-cache policy …\| Candidate`) |
+| `yq` | curl from GitHub releases | `v4.35.1` |
+| ROS 2 base | snapcraft extension `ros2-{distro}-ros-base` | distro = humble \| jazzy |
+| Snap Store | `snapcore/action-publish@v1` | tracks: `humble/edge`, `humble/candidate`, `jazzy/edge`, `jazzy/candidate` |
+| OAK-x camera | USB (raw-usb plug) or PoE/IP (preset `oak-d-pro-poe`, `i_ip: 10.15.20.6`) | — |
 
 ______________________________________________________________________
 
@@ -377,20 +377,20 @@ ______________________________________________________________________
 
 **Coverage versus upstream `camera.launch.py` jazzy 2.12.2**:
 
-| Upstream feature                                                                 | Status here                                                       |
-| -------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `ParameterFile(LaunchConfiguration("params_file"), allow_substs=True)`           | ✅                                                                |
-| `IfCondition(rectify_rgb)` + RectifyNode                                         | ✅ (per-camera name)                                              |
-| `IfCondition(pointcloud.enable)` + PointCloudXyzrgbNode                          | ✅ as `enable_pointcloud`                                         |
-| Sync overrides (`pipeline_gen.i_enable_sync`, `rgb.i_synced`, `stereo.i_synced`) | ✅ injected when PCL on                                           |
-| `tf_params` from `publish_tf_from_calibration` + `override_cam_model`            | ❌ removed as dead (Husarion uses own robot URDF; would conflict) |
-| `target_container` namespace-aware                                               | ✅ (with leading `/`)                                             |
-| Default `camera_model="OAK-D-PRO"`                                               | ✅ aligned (also in `snap/hooks/install`)                         |
-| Default `rectify_rgb="true"`                                                     | ✅ aligned                                                        |
-| `Node(rviz2)` + `use_rviz`                                                       | ❌ not needed (we have `image_view_launcher.sh`)                  |
-| `IncludeLaunchDescription(urdf_launch.py)`                                       | ❌ deliberately omitted                                           |
-| `rs_compat` (RealSense compat) + `enable_color/depth/infra*`, `*_profile` args   | ❌ deliberately omitted                                           |
-| `setup_launch_prefix` (gdb/valgrind/perf)                                        | ❌ omitted (snap strict confinement limits debug tools anyway)    |
+| Upstream feature | Status here |
+| -- | -- |
+| `ParameterFile(LaunchConfiguration("params_file"), allow_substs=True)` | ✅ |
+| `IfCondition(rectify_rgb)` + RectifyNode | ✅ (per-camera name) |
+| `IfCondition(pointcloud.enable)` + PointCloudXyzrgbNode | ✅ as `enable_pointcloud` |
+| Sync overrides (`pipeline_gen.i_enable_sync`, `rgb.i_synced`, `stereo.i_synced`) | ✅ injected when PCL on |
+| `tf_params` from `publish_tf_from_calibration` + `override_cam_model` | ❌ removed as dead (Husarion uses own robot URDF; would conflict) |
+| `target_container` namespace-aware | ✅ (with leading `/`) |
+| Default `camera_model="OAK-D-PRO"` | ✅ aligned (also in `snap/hooks/install`) |
+| Default `rectify_rgb="true"` | ✅ aligned |
+| `Node(rviz2)` + `use_rviz` | ❌ not needed (we have `image_view_launcher.sh`) |
+| `IncludeLaunchDescription(urdf_launch.py)` | ❌ deliberately omitted |
+| `rs_compat` (RealSense compat) + `enable_color/depth/infra*`, `*_profile` args | ❌ deliberately omitted |
+| `setup_launch_prefix` (gdb/valgrind/perf) | ❌ omitted (snap strict confinement limits debug tools anyway) |
 
 **Future decision**: could switch to `IncludeLaunchDescription(camera.launch.py)` mapping our `driver.*` to upstream args, but we'd lose control over node naming. Low priority — current coverage is complete.
 
@@ -402,17 +402,17 @@ ______________________________________________________________________
 
 ## 8. Extension points
 
-| Add                                         | Where                                                                                                                     |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| New `driver.X` parameter                    | `snap/hooks/{configure,install}` + `snap/local/{launcher.sh,depthai.launch.py}` (4 spots)                                 |
-| New camera YAML preset                      | add `camera-params-<NAME>.yaml` to `snap/local/`                                                                          |
-| New ffmpeg YAML preset                      | add `ffmpeg-params-<NAME>.yaml` to `snap/local/`                                                                          |
-| New DDS transport                           | PR to `husarion/husarion-snap-common` (`local-ros/rmw/<impl>/<NAME>.xml`) + bump pin in Jinja                             |
-| New apt dependency                          | `snapcraft_template.yaml.jinja2` → `parts.husarion-depthai.stage-packages`                                                |
-| New plug (e.g. `gpio`)                      | `snapcraft_template.yaml.jinja2` → `apps.daemon.plugs` + `apps.husarion-depthai.plugs` + `post_install.sh` (snap connect) |
-| New ROS distro (e.g. `kilted`)              | Jinja conditions on `core` per distro + matrix in CI + entry in `justfile`                                                |
-| New app (e.g. `husarion-depthai.calibrate`) | new entry in `apps:` in Jinja + script in `snap/local/`                                                                   |
-| New parameter validator                     | edit `husarion-snap-common/local-ros/utils.sh` + bump pin                                                                 |
+| Add | Where |
+| -- | -- |
+| New `driver.X` parameter | `snap/hooks/{configure,install}` + `snap/local/{launcher.sh,depthai.launch.py}` (4 spots) |
+| New camera YAML preset | add `camera-params-<NAME>.yaml` to `snap/local/` |
+| New ffmpeg YAML preset | add `ffmpeg-params-<NAME>.yaml` to `snap/local/` |
+| New DDS transport | PR to `husarion/husarion-snap-common` (`local-ros/rmw/<impl>/<NAME>.xml`) + bump pin in Jinja |
+| New apt dependency | `snapcraft_template.yaml.jinja2` → `parts.husarion-depthai.stage-packages` |
+| New plug (e.g. `gpio`) | `snapcraft_template.yaml.jinja2` → `apps.daemon.plugs` + `apps.husarion-depthai.plugs` + `post_install.sh` (snap connect) |
+| New ROS distro (e.g. `kilted`) | Jinja conditions on `core` per distro + matrix in CI + entry in `justfile` |
+| New app (e.g. `husarion-depthai.calibrate`) | new entry in `apps:` in Jinja + script in `snap/local/` |
+| New parameter validator | edit `husarion-snap-common/local-ros/utils.sh` + bump pin |
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ sudo /var/snap/husarion-depthai/common/post_install.sh   # connects raw-usb, har
 
 ## Apps
 
-| app                        | description                                          |
-| -------------------------- | ---------------------------------------------------- |
-| `husarion-depthai.start`   | Enable + start the `husarion-depthai.daemon` service |
-| `husarion-depthai.stop`    | Disable + stop the daemon                            |
-| `husarion-depthai.restart` | Restart the daemon                                   |
-| `husarion-depthai`         | Run in the foreground (stop the daemon first)        |
+| app | description |
+| -- | -- |
+| `husarion-depthai.start` | Enable + start the `husarion-depthai.daemon` service |
+| `husarion-depthai.stop` | Disable + stop the daemon |
+| `husarion-depthai.restart` | Restart the daemon |
+| `husarion-depthai` | Run in the foreground (stop the daemon first) |
 
 ## Configuration
 
@@ -51,21 +51,21 @@ Dump current settings: `snap get -d husarion-depthai`
 
 Bundled preset YAMLs live in `/var/snap/husarion-depthai/current/`:
 
-| preset                                   | hardware      | pipeline                     | notes                                                                                                                                                                                             |
-| ---------------------------------------- | ------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default`                                | any OAK-x     | RGB                          | 1280×720 @ 30 fps, raw RGB over USB                                                                                                                                                               |
-| `oak-1-lite`                             | OAK-1-LITE    | RGB                          | single-sensor IMX214                                                                                                                                                                              |
-| `oak-d-pro`                              | OAK-D-PRO     | RGBD + IMU + IR              | subpixel + lr_check + align_depth                                                                                                                                                                 |
-| `oak-d-pro-poe`                          | OAK-D-PRO-POE | RGBD + IMU + IR              | MJPEG quality 50, default IP `10.15.20.6`                                                                                                                                                         |
-| `oak-d-pro-slam`                         | OAK-D-PRO     | RGBD + IMU + IR              | manual exposure for VIO/SLAM feature trackers                                                                                                                                                     |
-| `rgb-h264-720p30`                        | any OAK-x     | RGB (chip H.264)             | OAK hardware H.264 on `…/rgb/image_raw/compressed` (FFMPEGPacket); no raw/rect/PCL — rectify + point-cloud forced off. fps/res variants: `rgb-h264-{360p30,360p60,720p60,1080p60,4k30}`           |
-| `depth-disp-h264`                        | OAK-D-class   | depth (chip H.264)           | chip H.264 of the 8-bit **disparity** (lossy view, not metric); RGB lazy. For external consumers — the cockpit has no depth viewer                                                                |
-| `rgb-raw-720p-h264-720p`                 | any OAK-x     | RGB (raw + h264)             | raw `…/rgb/image_raw` (autonomy) **and** on-chip H.264 `…/rgb/image_raw/compressed` (telepresence) at once, 720p @ 30 — via the `husarion_depthai_pipeline` plugin                                |
-| `rgb-raw-1080p-h264-1080p`               | any OAK-x     | RGB (raw + h264)             | as above at 1080p, 8.5 Mbps encoded                                                                                                                                                               |
-| `rgb-raw-360p-h264-360p`                 | any OAK-x     | RGB (raw + h264)             | as above at 360p, 1 Mbps encoded — survives weak links                                                                                                                                            |
-| `rgb-raw-1080p-h264-720p`                | any OAK-x     | RGB (raw + h264, asymmetric) | full-res 1080p raw + downscaled 720p H.264 (on-chip ImageManip)                                                                                                                                   |
-| `rgb-raw-360p-h264-720p`                 | any OAK-x     | RGB (raw + h264, asymmetric) | lightweight 360p raw + 720p H.264 view                                                                                                                                                            |
-| `rgbd-rgb-h264-720p-depth-raw-disp-h264` | OAK-D-class   | RGB + depth (raw + h264)     | RGB raw+H.264 plus depth 16UC1 raw + disparity grayscale-H.264 view (2D depth preview). Verified on OAK-D-LITE; needs a stereo OAK (`i_subpixel` must be false → 8-bit disparity for the encoder) |
+| preset | hardware | pipeline | notes |
+| -- | -- | -- | -- |
+| `default` | any OAK-x | RGB | 1280×720 @ 30 fps, raw RGB over USB |
+| `oak-1-lite` | OAK-1-LITE | RGB | single-sensor IMX214 |
+| `oak-d-pro` | OAK-D-PRO | RGBD + IMU + IR | subpixel + lr_check + align_depth |
+| `oak-d-pro-poe` | OAK-D-PRO-POE | RGBD + IMU + IR | MJPEG quality 50, default IP `10.15.20.6` |
+| `oak-d-pro-slam` | OAK-D-PRO | RGBD + IMU + IR | manual exposure for VIO/SLAM feature trackers |
+| `rgb-h264-720p30` | any OAK-x | RGB (chip H.264) | OAK hardware H.264 on `…/rgb/image_raw/compressed` (FFMPEGPacket); no raw/rect/PCL — rectify + point-cloud forced off. fps/res variants: `rgb-h264-{360p30,360p60,720p60,1080p60,4k30}` |
+| `depth-disp-h264` | OAK-D-class | depth (chip H.264) | chip H.264 of the 8-bit **disparity** (lossy view, not metric); RGB lazy. For external consumers — the cockpit has no depth viewer |
+| `rgb-raw-720p-h264-720p` | any OAK-x | RGB (raw + h264) | raw `…/rgb/image_raw` (autonomy) **and** on-chip H.264 `…/rgb/image_raw/compressed` (telepresence) at once, 720p @ 30 — via the `husarion_depthai_pipeline` plugin |
+| `rgb-raw-1080p-h264-1080p` | any OAK-x | RGB (raw + h264) | as above at 1080p, 8.5 Mbps encoded |
+| `rgb-raw-360p-h264-360p` | any OAK-x | RGB (raw + h264) | as above at 360p, 1 Mbps encoded — survives weak links |
+| `rgb-raw-1080p-h264-720p` | any OAK-x | RGB (raw + h264, asymmetric) | full-res 1080p raw + downscaled 720p H.264 (on-chip ImageManip) |
+| `rgb-raw-360p-h264-720p` | any OAK-x | RGB (raw + h264, asymmetric) | lightweight 360p raw + 720p H.264 view |
+| `rgbd-rgb-h264-720p-depth-raw-disp-h264` | OAK-D-class | RGB + depth (raw + h264) | RGB raw+H.264 plus depth 16UC1 raw + disparity grayscale-H.264 view (2D depth preview). Verified on OAK-D-LITE; needs a stereo OAK (`i_subpixel` must be false → 8-bit disparity for the encoder) |
 
 The filename carries the format: `rgb-h264-*` = chip H.264 only (no raw); `rgb-raw-*-h264-*` = raw **and** on-chip H.264 at once (the two resolutions are the raw leg and the encoder leg). The `rgb-raw-*` + `rgbd-*` presets use the bundled `husarion_depthai_pipeline` pluginlib plugin (selected via `camera.i_pipeline_type`) — raw + on-chip H.264 from one camera, no host encode. The cockpit telepresence feed auto-follows the on-chip `…/compressed` (badge: `sensor`) while autonomy nodes read the raw topic.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Snap for OAK-x cameras customized for Husarion robots.
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/husarion-depthai)
 
+## Install
+
+```bash
+sudo snap install husarion-depthai
+sudo /var/snap/husarion-depthai/common/post_install.sh   # connects raw-usb, hardware-observe, shm + restarts the daemon
+```
+
+`post_install.sh` connects the interfaces snapd does not auto-connect on sideloaded (`--dangerous` / `snap try`) installs; on a Snap Store install it is a no-op safety net.
+
 ## Apps
 
 | app                        | description                                          |

--- a/SPEC-camera-config.md
+++ b/SPEC-camera-config.md
@@ -1,23 +1,12 @@
 # SPEC — depthai parametric, capability-aware camera config
 
-Outstanding-work playbook for replacing the flat `camera-params-*.yaml` preset
-list with a **parametric, model-aware** camera configuration: the operator
-selects only the values the connected OAK supports, sees them rendered as
-values (not decoded from filenames), and the configure hook composes the single
-`camera-params` YAML depthai_ros_driver actually consumes.
+Outstanding-work playbook for replacing the flat `camera-params-*.yaml` preset list with a **parametric, model-aware** camera configuration: the operator selects only the values the connected OAK supports, sees them rendered as values (not decoded from filenames), and the configure hook composes the single `camera-params` YAML depthai_ros_driver actually consumes.
 
-Delete this file once all phases ship; migrate durable invariants into
-`CLAUDE.md` / `ARCHITECTURE.md` as they land.
+Delete this file once all phases ship; migrate durable invariants into `CLAUDE.md` / `ARCHITECTURE.md` as they land.
 
 ## Why
 
-A preset filename tries to be the whole spec. That collapses once a config has
-two legs (raw + H.264) × two streams (RGB + depth) × resolution × fps × model
-compatibility — `rgb-raw-1080p30-h264-720p30-depth-raw-400p30-disp-h264-400p30`
-is unreadable and still can't say "needs a stereo camera." The fix: make the
-camera's **capabilities** the source of truth, the config a **validated,
-parametric choice** on top, and the UI **display the values**. The verbose
-explicit name becomes an auto-generated label, never hand-maintained.
+A preset filename tries to be the whole spec. That collapses once a config has two legs (raw + H.264) × two streams (RGB + depth) × resolution × fps × model compatibility — `rgb-raw-1080p30-h264-720p30-depth-raw-400p30-disp-h264-400p30` is unreadable and still can't say "needs a stereo camera." The fix: make the camera's **capabilities** the source of truth, the config a **validated, parametric choice** on top, and the UI **display the values**. The verbose explicit name becomes an auto-generated label, never hand-maintained.
 
 ## Decisions (locked via interview)
 
@@ -38,43 +27,27 @@ explicit name becomes an auto-generated label, never hand-maintained.
 
 ### 1. Capability probe (`camera` snap, new)
 
-A small probe the configure/apply hook runs **before** composing the YAML
-(works even when `husarion-depthai.daemon` is stopped):
+A small probe the configure/apply hook runs **before** composing the YAML (works even when `husarion-depthai.daemon` is stopped):
 
-- Uses the depthai API (python) to detect the connected device: **model**
-  (OAK-1 / OAK-D-LITE / OAK-D-PRO / OAK-D-PRO-POE / …), **sensors** present
-  (mono pair? IMX378 vs IMX214?), **IR** present, **IMU** present, and the
-  **supported resolutions/fps** per sensor.
+- Uses the depthai API (python) to detect the connected device: **model** (OAK-1 / OAK-D-LITE / OAK-D-PRO / OAK-D-PRO-POE / …), **sensors** present (mono pair? IMX378 vs IMX214?), **IR** present, **IMU** present, and the **supported resolutions/fps** per sensor.
 - Writes `…/camera/capabilities.json` (the dynamic-enum source).
-- PoE: needs `i_ip` to reach the device → the probe reads the `camera` concern's
-  `ip` field first (see Open Q4).
-- No device reachable → fall back to a shipped **static capability matrix**
-  keyed by the operator-declared `model` (see Open Q3).
+- PoE: needs `i_ip` to reach the device → the probe reads the `camera` concern's `ip` field first (see Open Q4).
+- No device reachable → fall back to a shipped **static capability matrix** keyed by the operator-declared `model` (see Open Q3).
 
 ### 2. `camera` files-first concern (manifest with sections)
 
-One concern, rendered by the existing Manage generic renderer
-(`webui` `ConfigSubview`), fields backed by **dynamic enums** sourced from
-`capabilities.json` so only valid values appear. Sections (each a Manage card,
-shown only when the detected model supports it):
+One concern, rendered by the existing Manage generic renderer (`webui` `ConfigSubview`), fields backed by **dynamic enums** sourced from `capabilities.json` so only valid values appear. Sections (each a Manage card, shown only when the detected model supports it):
 
-- **rgb** — `resolution` (enum), `fps` (enum, gated on resolution), `raw`
-  (bool), `h264` (bool), `h264_bitrate`, optional asymmetric `enc_width/height`.
-- **depth** (stereo models only) — `enabled`, `disparity_h264` (bool, 2D
-  preview), `metric_raw` (bool, 16UC1), `resolution`, `fps`, `align_to_rgb`,
-  `lr_check`. (`subpixel` is **derived**, not exposed — see rules.)
+- **rgb** — `resolution` (enum), `fps` (enum, gated on resolution), `raw` (bool), `h264` (bool), `h264_bitrate`, optional asymmetric `enc_width/height`.
+- **depth** (stereo models only) — `enabled`, `disparity_h264` (bool, 2D preview), `metric_raw` (bool, 16UC1), `resolution`, `fps`, `align_to_rgb`, `lr_check`. (`subpixel` is **derived**, not exposed — see rules.)
 - **imu** (models with an IMU) — `enabled`.
 - **ir** (Pro/PoE only) — `enabled`, optional `dot_brightness` / `flood_brightness`.
 - **pointcloud** (stereo models) — `enabled` (RGBD pipelines only).
-- top-level — `model` (auto-detected, operator-overridable), `ip` (PoE),
-  `startup_delay`.
+- top-level — `model` (auto-detected, operator-overridable), `ip` (PoE), `startup_delay`.
 
 ### 3. Compose + derive hook (`camera` snap, the heart)
 
-The hook reads the concern, **derives** the coupled fields, deep-merges into the
-single `camera-params` YAML, `snap set driver.camera-params=<generated>`, and
-restarts the daemon. Derivation table (RGB+depth are NOT independent — they pick
-one `camera.i_pipeline_type`):
+The hook reads the concern, **derives** the coupled fields, deep-merges into the single `camera-params` YAML, `snap set driver.camera-params=<generated>`, and restarts the daemon. Derivation table (RGB+depth are NOT independent — they pick one `camera.i_pipeline_type`):
 
 | Enabled streams | `i_pipeline_type` |
 | -- | -- |
@@ -87,20 +60,16 @@ one `camera.i_pipeline_type`):
 
 Cross-constraints the hook enforces (reject or auto-fix + warn):
 
-- **disparity-H.264 ⇒ `stereo.i_subpixel=false`** (8-bit disparity for the
-  on-chip encoder; subpixel makes it 16-bit → encoder rejects it).
+- **disparity-H.264 ⇒ `stereo.i_subpixel=false`** (8-bit disparity for the on-chip encoder; subpixel makes it 16-bit → encoder rejects it).
 - **depth / pointcloud ⇒ stereo-capable model** (never OAK-1).
 - **IR enabled ⇒ Pro/PoE** (no-op + warn on Lite).
 - **4K ⇒ IMX378/IMX214** (per probe).
-- **dual plugins ⇒** the `husarion_depthai_pipeline` part is built into the snap
-  AND the raw stream's image_transport republisher is suppressed
-  (`<node>.rgb.image_raw.enable_pub_plugins: ['image_transport/raw']`).
+- **dual plugins ⇒** the `husarion_depthai_pipeline` part is built into the snap AND the raw stream's image_transport republisher is suppressed (`<node>.rgb.image_raw.enable_pub_plugins: ['image_transport/raw']`).
 - **PoE ⇒ `i_ip` set**.
 
 ### 4. Naming generator
 
-Deterministic label from the enabled fragments (locked grammar — `p`-shorthand,
-fps glued, depth legs mirror RGB):
+Deterministic label from the enabled fragments (locked grammar — `p`-shorthand, fps glued, depth legs mirror RGB):
 
 ```
 rgb-<raw|h264|raw-…-h264>-<res>p<fps>[…asymmetric]
@@ -108,37 +77,25 @@ rgb-<raw|h264|raw-…-h264>-<res>p<fps>[…asymmetric]
   [-imu-on][-ir-on]
 ```
 
-e.g. `rgb-raw-1080p30-h264-720p30-depth-disp-h264-400p30-imu-on`. Same generator
-names shipped bundles and operator-saved presets.
+e.g. `rgb-raw-1080p30-h264-720p30-depth-disp-h264-400p30-imu-on`. Same generator names shipped bundles and operator-saved presets.
 
 ### 5. Manage + Operate (webui)
 
-- **Manage:** per-capability cards (§2) via the existing concern renderer +
-  dynamic enums. Apply runs the compose+derive hook → snap restart (reuse the
-  streaming-apply UX).
-- **Operate (v1):** read-only summary chip of the active pipeline. The
-  model-filtered quick-switch of saved presets is a **follow-up** — it mixes a
-  runtime source-switch (the existing husarion_camera switcher) with a snap
-  reconfig + restart, so it's kept out of v1.
+- **Manage:** per-capability cards (§2) via the existing concern renderer + dynamic enums. Apply runs the compose+derive hook → snap restart (reuse the streaming-apply UX).
+- **Operate (v1):** read-only summary chip of the active pipeline. The model-filtered quick-switch of saved presets is a **follow-up** — it mixes a runtime source-switch (the existing husarion_camera switcher) with a snap reconfig + restart, so it's kept out of v1.
 
 ## Phases
 
-1. **Probe** (enumerate all OAKs + caps → `capabilities.json`) **+ static
-   matrix fallback** (snap).
-2. **`camera` concern manifest** (sections + `mxid`/`ip`) **+ compose/derive
-   hook** (snap).
-3. **Naming generator** (shared rule; snap-side for files, webui-side for
-   display labels) **+ migrate all 18 current presets** into bundles via it.
-4. **Manage cards + dynamic enums** (verify the generic renderer covers
-   sections + model-gating; extend if needed) (agent/webui).
+1. **Probe** (enumerate all OAKs + caps → `capabilities.json`) **+ static matrix fallback** (snap).
+2. **`camera` concern manifest** (sections + `mxid`/`ip`) **+ compose/derive hook** (snap).
+3. **Naming generator** (shared rule; snap-side for files, webui-side for display labels) **+ migrate all 18 current presets** into bundles via it.
+4. **Manage cards + dynamic enums** (verify the generic renderer covers sections + model-gating; extend if needed) (agent/webui).
 5. **Operate read-only summary chip** (webui). *(Quick-switch = follow-up.)*
 6. **Retire the old `camera-params-*.yaml`**; docs; drift check.
 
 ## Resolved (all closed via interview — no blockers)
 
-1. **Operate ↔ source switcher** → **Manage-only for v1**; the Operate
-   depthai quick-switch is a follow-up (avoids mixing runtime source-switch with
-   reconfig+restart).
+1. **Operate ↔ source switcher** → **Manage-only for v1**; the Operate depthai quick-switch is a follow-up (avoids mixing runtime source-switch with reconfig+restart).
 2. **Shipped bundles** → **migrate all 18** existing presets into the new format.
 3. **No camera at probe** → **static capability matrix** by declared `model`.
 4. **PoE `i_ip`** → top-level `camera`-concern field, consumed by the probe first.
@@ -146,15 +103,10 @@ names shipped bundles and operator-saved presets.
 
 ### Multi-OAK note (Phase 1 impact)
 
-The probe enumerates every connected OAK + its caps; the `camera` concern gains
-an `mxid` field (dynamic enum of detected devices). The hook passes the selected
-`mxid` (and `i_ip` for PoE) to the driver. Per-device config is one concern
-targeting one `mxid` in v1 (multiple simultaneous OAK pipelines = future work).
+The probe enumerates every connected OAK + its caps; the `camera` concern gains an `mxid` field (dynamic enum of detected devices). The hook passes the selected `mxid` (and `i_ip` for PoE) to the driver. Per-device config is one concern targeting one `mxid` in v1 (multiple simultaneous OAK pipelines = future work).
 
 ## Touchpoints outside this repo
 
-- `husarion-agent` (cockpit repo) — files-first concern manifest format +
-  dynamic-enum resolver; confirm sections + model-gating are expressible
-  (`AGENT-files-first.md`).
+- `husarion-agent` (cockpit repo) — files-first concern manifest format + dynamic-enum resolver; confirm sections + model-gating are expressible (`AGENT-files-first.md`).
 - `husarion-cockpit/webui` — Manage card rendering (generic, likely no change)
-  + Operate quick-switch (new).
+  - Operate quick-switch (new).

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -86,12 +86,12 @@ if [ -d "${SNAP_COMMON}/husarion-agent/config" ]; then
     # first apply.
     write_caps() { d="${SNAP_DATA}/caps/$1"; rm -rf "$d"; mkdir -p "$d"; shift; for v in "$@"; do : > "${d}/${v}.opt"; done; }
     write_caps model OAK-1 OAK-1-LITE OAK-D OAK-D-LITE OAK-D-PRO OAK-D-PRO-W
-    case "$cam_model" in OAK-1-LITE|OAK-D-LITE) rgb_fps_opts="30" ;; *) rgb_fps_opts="30 60" ;; esac
+    case "$cam_model" in OAK-1-LITE|OAK-D-LITE) rgb_fps_opts=(30) ;; *) rgb_fps_opts=(30 60) ;; esac
     write_caps rgb_resolution 720P 1080P 4K
-    write_caps rgb_fps $rgb_fps_opts
+    write_caps rgb_fps "${rgb_fps_opts[@]}"
     if [ "$has_stereo" = true ]; then
-        case "$cam_model" in OAK-D-LITE) depth_res_opts="400P 480P" ;; *) depth_res_opts="400P 720P 800P" ;; esac
-        write_caps depth_resolution $depth_res_opts
+        case "$cam_model" in OAK-D-LITE) depth_res_opts=(400P 480P) ;; *) depth_res_opts=(400P 720P 800P) ;; esac
+        write_caps depth_resolution "${depth_res_opts[@]}"
         write_caps depth_fps 30 60
     fi
     log "camera concern caps: model=$cam_model stereo=$has_stereo imu=$has_imu ir=$has_ir"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -54,8 +54,9 @@ fi
 # Always overwrite bundled presets with the version shipped in this revision.
 cp "${SNAP}/usr/share/${SNAP_NAME}/config"/*.yaml "${SNAP_DATA}/"
 
-# Refresh the on-device operator/AI usage guide from this revision.
+# Refresh the on-device operator/AI usage guide + post_install helper from this revision.
 cp -f "$SNAP/usr/share/${SNAP_NAME}/AGENTS.md" "${SNAP_COMMON}/AGENTS.md"
+cp -f "$SNAP/usr/bin/post_install.sh" "${SNAP_COMMON}/"
 
 # Apply defaults for driver.* params added in this revision (idempotent —
 # existing user-set values are preserved).

--- a/snapcraft_template.yaml.jinja2
+++ b/snapcraft_template.yaml.jinja2
@@ -6,6 +6,14 @@ icon: snap/gui/icon.png
 description: |
   The `husarion-depthai` snap contains all the necessary software to bring the OAK-x cameras up.
 
+  **Installation**
+
+     sudo snap install husarion-depthai
+
+  After installation, connect the required interfaces (`raw-usb`, `hardware-observe`, shared memory) and restart the driver:
+
+     sudo /var/snap/husarion-depthai/common/post_install.sh
+
   **Tip**
 
   The default camera parameters do not include depth image computation. To enable depth topic transmission, set the parameter to `i_pipeline_type: RGBD`. Path to params file: `/var/snap/husarion-depthai/current/camera-params-default.yaml`


### PR DESCRIPTION
The snap has shipped `post_install.sh` (connects `raw-usb`, `hardware-observe`, `shm-plug↔shm-slot`, restarts the daemon) for a while, but nothing user-facing mentioned it — store users never learned to run it.

- Snap Store description gains an **Installation** section with the `sudo /var/snap/husarion-depthai/common/post_install.sh` step (same style as rosbot).
- README gains an **Install** section with the same two commands.
- post-refresh hook now re-copies `post_install.sh` into `${SNAP_COMMON}` on every refresh (previously only the install hook copied it, so upgraded installs kept a stale helper forever).